### PR TITLE
Set committer date

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,9 @@
+import { execSync } from "child_process";
+import { mkdirSync, readFileSync, rmSync } from "fs";
 import path from "path";
-import { rmSync, mkdirSync, readFileSync } from "fs";
+import * as R from "ramda";
 import { simpleGit } from "simple-git";
 import { getCommitList } from "./getCommitList";
-import * as R from "ramda";
 
 const { repositories, emails, remote } = JSON.parse(
   readFileSync("./repos.json").toString()
@@ -51,11 +52,13 @@ if (!Array.isArray(repositories) || !Array.isArray(emails)) {
 
   console.log('Starting to commit to "./test-git-repo"');
 
+  process.chdir(TEST_REPO);
+
   for (const commit of sortedCommits) {
-    await git.commit("Another commit", {
-      "--allow-empty": null,
-      "--date": commit.date,
-    });
+    const gitCommand = `GIT_AUTHOR_DATE="${commit.date}" GIT_COMMITTER_DATE="${commit.date}" git commit --allow-empty --no-gpg-sign -m "Another commit"`;
+
+    execSync(gitCommand, { encoding: "utf8" });
+
     process.stdout.write(".");
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/tmp": "^0.2.3",
         "ramda": "^0.28.0",
         "simple-git": "^3.15.0",
         "tmp": "^0.2.1",
         "typescript": "^4.9.3"
       },
       "devDependencies": {
+        "@types/ramda": "^0.28.20",
+        "@types/tmp": "^0.2.3",
         "ts-node": "^10.9.1"
       }
     },
@@ -100,10 +101,20 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/@types/ramda": {
+      "version": "0.28.20",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.28.20.tgz",
+      "integrity": "sha512-MeUhzGSXQTRsY19JGn5LIBTLxVEnyF6HDNr08KSJqybsm4DlfLIgK1jBHjhpiSyk252tXYmp+UOe0UFg0UiFsA==",
+      "dev": true,
+      "dependencies": {
+        "ts-toolbelt": "^6.15.1"
+      }
+    },
     "node_modules/@types/tmp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA=="
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -349,6 +360,12 @@
         }
       }
     },
+    "node_modules/ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "dev": true
+    },
     "node_modules/typescript": {
       "version": "4.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
@@ -458,10 +475,20 @@
       "dev": true,
       "peer": true
     },
+    "@types/ramda": {
+      "version": "0.28.20",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.28.20.tgz",
+      "integrity": "sha512-MeUhzGSXQTRsY19JGn5LIBTLxVEnyF6HDNr08KSJqybsm4DlfLIgK1jBHjhpiSyk252tXYmp+UOe0UFg0UiFsA==",
+      "dev": true,
+      "requires": {
+        "ts-toolbelt": "^6.15.1"
+      }
+    },
     "@types/tmp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA=="
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
     },
     "acorn": {
       "version": "8.8.1",
@@ -635,6 +662,12 @@
         "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       }
+    },
+    "ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "dev": true
     },
     "typescript": {
       "version": "4.9.3",

--- a/package.json
+++ b/package.json
@@ -4,19 +4,21 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "ts-node index.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@types/tmp": "^0.2.3",
     "ramda": "^0.28.0",
     "simple-git": "^3.15.0",
     "tmp": "^0.2.1",
     "typescript": "^4.9.3"
   },
   "devDependencies": {
+    "@types/ramda": "^0.28.20",
+    "@types/tmp": "^0.2.3",
     "ts-node": "^10.9.1"
   }
 }


### PR DESCRIPTION
### badc0dee373d44065dba0df9a71051b5a6ad9a52 – Tweak command to set `GIT_AUTHOR_DATE` and `GIT_COMMITTER_DATE`

This is because the `--date` argument only sets the author date. I believe it's nicer to also have the committer date set, so all commits aren't shown with the same date in clients like Sublime Merge.

I have also added the argument `--no-gpg-sign`, as it makes the process faster and having signatures isn't useful in this case.

### d046d466a2cd562dc5914c782b451643e527bf70 – Add types for ramda and create start script
