### PR TITLE
Fix contributions being counted multiple times by GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # `own-contribution-graph`
 
-Say your company doesn't use GitHub, but you still want to continue your
-contribution graph on your GitHub account.
+Say your company doesn't use GitHub, but you still want to continue your contribution graph on your GitHub account.
 
-This tool will scan local repositories, and create a new repository with a
-series of empty commits that replicate your contributions seen in the local
-repositories.
+This tool will scan local repositories, and create a new repository with a series of empty commits that replicate your contributions seen in the local repositories.
 
 ## Usage
 
@@ -50,6 +47,4 @@ owncontributiongraph --config=<json-config-file-path>
 
 Push this repo to GitHub, or anywhere else.
 
-## TODO
-
-- [ ] Output the commit graph as HTML so it can be published on personal websites
+On subsequent runs, only new commits will be added to the contribution repository.

--- a/src/getCommitList.ts
+++ b/src/getCommitList.ts
@@ -4,6 +4,7 @@ import { chdir, cwd, exit } from "process";
 import { error } from "./common";
 
 export interface Commit {
+	hash: string;
 	authorEmail: string;
 	date: string;
 	repoName: string;
@@ -46,7 +47,7 @@ export const getCommitList = ({
 		.join(" ");
 
 	const revListOutput = execSync(
-		`git rev-list ${filterFlags} --format="format:%ae %cI" ${branchName}`,
+		`git rev-list ${filterFlags} --format="format:%H %ae %cI" ${branchName}`,
 		{ encoding: "utf8" },
 	);
 
@@ -54,7 +55,8 @@ export const getCommitList = ({
 		.split("\n")
 		.filter((s) => !s.startsWith("commit ") && s.trim().length > 0)
 		.map((s) => s.split(" "))
-		.map(([authorEmail, date]) => ({
+		.map(([hash, authorEmail, date]) => ({
+			hash,
 			authorEmail,
 			date,
 			repoName,

--- a/src/replicateContributions.ts
+++ b/src/replicateContributions.ts
@@ -3,7 +3,6 @@ import {
 	existsSync,
 	mkdirSync,
 	readdirSync,
-	rmSync,
 	statSync,
 	writeFileSync,
 } from "fs";
@@ -43,7 +42,7 @@ export const replicateContributions = ({
 
 	const resultSummary = `analysed ${numberOfRepos} ${
 		numberOfRepos === 1 ? "repository" : "repositories"
-	} — found ${numberOfCommits} ${
+	} and found ${numberOfCommits} ${
 		numberOfCommits === 1 ? "commit" : "commits"
 	} in ${numberOfReposWithCommits} ${
 		numberOfReposWithCommits === 1 ? "repository" : "repositories"
@@ -51,11 +50,19 @@ export const replicateContributions = ({
 
 	console.info(`\n${bgGreen}${fgWhite}${resultSummary}${reset}\n`);
 
-	initRepoAndJumpIn(contributionsRepository);
-
-	createInitialCommit(contributionsRepository.path, resultSummary);
+	prepareRepo(contributionsRepository);
 
 	createContributionCommits(contributionsRepository, sortedCommits);
+
+	writeFileSync(
+		`${contributionsRepository.path}/${readmeFileName}`,
+		`[own-contribution-graph](https://github.com/Georift/own-contribution-graph) ${resultSummary}.\n`,
+	);
+
+	if (execSync("git diff", { encoding: "utf8" })) {
+		execSync(`git add ${readmeFileName}`);
+		execSync("git commit -m 'Update readme'");
+	}
 
 	console.info(`\n\n${bgGreen}${fgWhite}success${reset}\n`);
 };
@@ -85,61 +92,96 @@ const getSourcePaths = (paths: string[]) =>
 		}
 	});
 
-const initRepoAndJumpIn = ({
-	path,
-	remote,
-}: Config["contributionsRepository"]) => {
+/**
+ * `chdir` to the contribution repository, creating one if it doesn't exist yet
+ *
+ * Note: we used to delete the contribution repository and recreate it from scratch at
+ * every runs, but we noticed that GitHub was adding contributions instead of replacing them:
+ * a contribution on one day way counted in the contribution graph everytime the repository
+ * was recreated, so the graph ended up showing ten contributions on this day, instead of one;
+ * to fix that, we now only add new/missing contributions to the contribution repository
+ */
+const prepareRepo = ({ path, remote }: Config["contributionsRepository"]) => {
+	if (!existsSync(path)) {
+		console.info(`Creating new contribution repository in '${path}'`);
+
+		mkdirSync(path);
+		chdir(path);
+		execSync("git init 2> /dev/null");
+
+		if (remote) {
+			execSync(`git remote add ${remote}`);
+		}
+
+		writeFileSync(`${path}/${safetyFileName}`, "");
+		writeFileSync(`${path}/${readmeFileName}`, "");
+		execSync(`git add ${safetyFileName} ${readmeFileName}`);
+		execSync("git commit -m 'Initial commit'");
+
+		return;
+	}
+
 	if (
-		existsSync(path) &&
-		(!statSync(path).isDirectory() ||
-			!R.equals(readdirSync(path), [".git", safetyFileName, readmeFileName]))
+		!statSync(path).isDirectory() ||
+		!R.equals(readdirSync(path), [".git", safetyFileName, readmeFileName])
 	) {
+		console.error(`${error} repository '${path}' is invalid.`);
+		exit(1);
+	}
+
+	chdir(path);
+
+	if (execSync("git diff", { encoding: "utf8" })) {
 		console.error(
-			`${error} repository '${path}' appears to have been touched; delete it manually or set another path.`,
+			`${error} repository '${path}' is invalid or has unstaged changes.`,
 		);
 		exit(1);
 	}
 
-	if (existsSync(path)) {
-		rmSync(path, { recursive: true });
-	}
-
-	mkdirSync(path);
-
-	chdir(path);
-
-	execSync("git init 2> /dev/null");
-
-	if (remote) {
-		execSync(`git remote add ${remote}`);
-	}
+	console.info(`Found existing contribution repository in '${path}'`);
 };
 
-const createInitialCommit = (path: string, resultSummary: string) => {
-	writeFileSync(`${path}/${safetyFileName}`, "");
-
-	writeFileSync(
-		`${path}/${readmeFileName}`,
-		`[own-contribution-graph](https://github.com/Georift/own-contribution-graph) ${resultSummary}.\n`,
-	);
-
-	execSync(`git add ${safetyFileName} ${readmeFileName}`);
-
-	execSync("git commit -m 'Initial commit'");
-};
-
+/**
+ * Add missing contribution commits to the contribution repository
+ *
+ * Note: in the future, we could implement the detection and removal of existing contribution commits
+ * that do not exist anymore in their original repositories; it doesn't seem very important though
+ */
 const createContributionCommits = (
 	{ path, includeRepositoryNameInCommits }: Config["contributionsRepository"],
 	commits: Commit[],
 ) => {
-	console.info(`Creating commits in '${path}':`);
+	const existingCommitsOutput = execSync(`git log --format="format:%b"`, {
+		encoding: "utf8",
+	});
 
-	commits.forEach((commit) => {
+	const existingCommits = existingCommitsOutput
+		.split("\n")
+		.filter((commitMessage) => commitMessage.match(/^[0-9a-f]{40}$/));
+
+	if (existingCommits.length) {
+		console.info(
+			`Found ${existingCommits.length} already existing contribution commits`,
+		);
+	}
+
+	const newCommits = commits.filter(
+		(commit) => !existingCommits.includes(commit.hash),
+	);
+
+	if (!newCommits.length) {
+		console.info(`No new contribution commits to be created.`);
+		return;
+	}
+
+	console.info(`Creating ${newCommits.length} contribution commits:`);
+
+	newCommits.forEach((commit) => {
 		const gitCommand = `GIT_AUTHOR_DATE="${commit.date}" GIT_COMMITTER_DATE="${
 			commit.date
 		}" git commit --allow-empty --no-gpg-sign -m "Commit${
 			includeRepositoryNameInCommits ? ` in '${commit.repoName}'` : ""
-		}"`;
+		}" -m ${commit.hash}`;
 
 		execSync(gitCommand);
 


### PR DESCRIPTION
To prevent GitHub from counting the same contribution more than once — see details in `prepareRepo`'s doc — we use the hash of each commit to identify if it's already present in the contribution repository. We do not recreate the contribution repository from scratch anymore, we keep it and only add missing contribution commits to it.

---

![Screenshot from 2023-08-11 17-20-15](https://github.com/Georift/own-contribution-graph/assets/29386932/42d8726c-78a1-40e6-b9e9-1effc8071b6b)

![Screenshot from 2023-08-11 17-21-48](https://github.com/Georift/own-contribution-graph/assets/29386932/e075c09a-2ac8-482e-b85e-742d0bc2f08c)

![Screenshot from 2023-08-11 17-22-12](https://github.com/Georift/own-contribution-graph/assets/29386932/dc3cbd21-2aac-49cb-9a7c-2dedbed98ad0)
